### PR TITLE
2-to-string-is-considered-a-single-word-tostring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- "__toString" will now be correctly understood as 2 words "to" and "string" instead of "tostring" ([#2](https://github.com/khalyomede/php-typo/issues/2)).
+
 ## [0.1.0] - 2022-08-21
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "require": {
         "php": ">=8.1.0",
         "nikic/php-parser": "^4.0",
-        "jawira/case-converter": "^3.0",
-        "symfony/console": "^6.0"
+        "symfony/console": "^6.0",
+        "aminnairi/string-extra": "0.1.0"
     },
     "bin": [
         "bin/php-typo"

--- a/composer.lock
+++ b/composer.lock
@@ -4,74 +4,49 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a362b91afc3642d5a775b373d3605fd",
+    "content-hash": "5f65022572e23a290cbeea38317f731e",
     "packages": [
         {
-            "name": "jawira/case-converter",
-            "version": "v3.5.1",
+            "name": "aminnairi/string-extra",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jawira/case-converter.git",
-                "reference": "2be05b98dcb743bef60ab6f849145bd3434ed003"
+                "url": "https://github.com/aminnairi/php-string-extra.git",
+                "reference": "a2bf0f566f5b8d76716654ebcf434a94a70df458"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jawira/case-converter/zipball/2be05b98dcb743bef60ab6f849145bd3434ed003",
-                "reference": "2be05b98dcb743bef60ab6f849145bd3434ed003",
+                "url": "https://api.github.com/repos/aminnairi/php-string-extra/zipball/a2bf0f566f5b8d76716654ebcf434a94a70df458",
+                "reference": "a2bf0f566f5b8d76716654ebcf434a94a70df458",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "php": ">=7.4"
+                "php": ">=8.0.0"
             },
             "require-dev": {
-                "behat/behat": "^3.0",
-                "phpstan/phpstan": "^1.0",
-                "phpunit/phpunit": "^9.0",
-                "vimeo/psalm": "^4.0"
-            },
-            "suggest": {
-                "pds/skeleton": "PHP Package Development Standards",
-                "phing/phing": "PHP Build Tool"
+                "pestphp/pest": "^1.22"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Jawira\\CaseConverter\\": "src/"
+                    "Aminnairi\\StringExtra\\": "./sources/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "GPL-3.0-or-later"
             ],
-            "authors": [
-                {
-                    "name": "Jawira Portugal",
-                    "email": "dev@tugal.be"
-                }
-            ],
-            "description": "Convert strings between 13 naming conventions: Snake case, Camel case, Pascal case, Kebab case, Ada case, Train case, Cobol case, Macro case, Upper case, Lower case, Sentence case, Title case and Dot notation.",
-            "homepage": "https://jawira.github.io/case-converter/",
+            "description": "Extra utilities for working with strings in PHP.",
+            "homepage": "https://github.com/aminnairi/php-string-extra",
             "keywords": [
-                "Ada case",
-                "Cobol case",
-                "Macro case",
-                "Train case",
-                "camel case",
-                "dot notation",
-                "kebab case",
-                "lower case",
-                "pascal case",
-                "sentence case",
-                "snake case",
-                "title case",
-                "upper case"
+                "extra",
+                "string"
             ],
             "support": {
-                "issues": "https://github.com/jawira/case-converter/issues",
-                "source": "https://github.com/jawira/case-converter/tree/v3.5.1"
+                "issues": "https://github.com/aminnairi/php-string-extra/issues",
+                "source": "https://github.com/aminnairi/php-string-extra/tree/0.1.0"
             },
-            "time": "2022-08-14T11:40:18+00:00"
+            "time": "2022-09-03T20:54:34+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/src/AstVisitor.php
+++ b/src/AstVisitor.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Khalyomede\PhpTypo;
 
+use Aminnairi\StringExtra\StringExtra;
 use Exception;
-use Jawira\CaseConverter\Convert;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
@@ -161,8 +161,7 @@ final class AstVisitor extends NodeVisitorAbstract
     private static function getWordsFromNodeName(Node $node): array
     {
         $nodeName = self::getNodeName($node);
-        $name = new Convert($nodeName);
 
-        return explode(" ", $name->toLower());
+        return array_map(fn (string $word): string => strtolower($word), explode(" ", StringExtra::toSentenceCase($nodeName)));
     }
 }

--- a/tests/CheckTest.php
+++ b/tests/CheckTest.php
@@ -31,7 +31,7 @@ test('it can run check which checks for typos', function (): void {
     $output = $commandTester->getDisplay();
 
     expect($output)->toContain(join("\n", [
-        "TTTTTTTTTTT",
+        "TTTTTTTTTT.T",
         "",
         "tests/misc/class-constant-typos.php:7",
         '  class constant "APLICATION_PLAIN" contains an unknown word "aplication".',
@@ -70,7 +70,7 @@ test('it can run check which checks for typos', function (): void {
         '  variable "gretingMessage" contains an unknown word "greting".',
         "",
         "Total typos  12",
-        "Total files  11",
+        "Total files  12",
     ]));
     expect($code)->toBe(1);
 });

--- a/tests/misc/to-string.php
+++ b/tests/misc/to-string.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+class Point
+{
+    public function __construct(public readonly float $x, public readonly float $y)
+    {
+    }
+
+    public function __toString()
+    {
+        return "{$this->x} {$this->y}";
+    }
+}


### PR DESCRIPTION
## Added

N/A

## Fixed

- "__toString" is counted as 2 words "to" and "string" instead of "tostring"

## Breaking

N/A