### PR TITLE
1-ignore-words-not-containing-letters-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Reduced false positives by ignoring numbers ([#1](https://github.com/khalyomede/php-typo/issues/1)).
+
 ### Fixed
 
 - "__toString" will now be correctly understood as 2 words "to" and "string" instead of "tostring" ([#2](https://github.com/khalyomede/php-typo/issues/2)).

--- a/src/AstVisitor.php
+++ b/src/AstVisitor.php
@@ -161,7 +161,8 @@ final class AstVisitor extends NodeVisitorAbstract
     private static function getWordsFromNodeName(Node $node): array
     {
         $nodeName = self::getNodeName($node);
+        $words = explode(" ", StringExtra::toSentenceCase($nodeName));
 
-        return array_map(fn (string $word): string => strtolower($word), explode(" ", StringExtra::toSentenceCase($nodeName)));
+        return Words::clean($words);
     }
 }

--- a/src/Words.php
+++ b/src/Words.php
@@ -78,4 +78,40 @@ final class Words
     {
         self::$words = array_diff(self::$words, $words);
     }
+
+    /**
+     * @param array<string> $wordsAndNumbers
+     *
+     * @return array<string>
+     */
+    public static function clean(array $wordsAndNumbers): array
+    {
+        return self::lowerWords(self::keepWordsOnly($wordsAndNumbers));
+    }
+
+    /**
+     * @param array<string> $wordsAndNumbers
+     *
+     * @return array<string>
+     */
+    public static function keepWordsOnly(array $wordsAndNumbers): array
+    {
+        return array_filter(
+            $wordsAndNumbers,
+            fn (string $word): bool => preg_match("/^[^0-9]+$/", $word) === 1
+        );
+    }
+
+    /**
+     * @param array<string> $words
+     *
+     * @return array<string>
+     */
+    private static function lowerWords(array $words): array
+    {
+        return array_map(
+            fn (string $word): string => strtolower($word),
+            $words
+        );
+    }
 }

--- a/tests/CheckTest.php
+++ b/tests/CheckTest.php
@@ -31,7 +31,7 @@ test('it can run check which checks for typos', function (): void {
     $output = $commandTester->getDisplay();
 
     expect($output)->toContain(join("\n", [
-        "TTTTTTTTTT.T",
+        "TTTTTTTTTT.T.",
         "",
         "tests/misc/class-constant-typos.php:7",
         '  class constant "APLICATION_PLAIN" contains an unknown word "aplication".',
@@ -70,7 +70,7 @@ test('it can run check which checks for typos', function (): void {
         '  variable "gretingMessage" contains an unknown word "greting".',
         "",
         "Total typos  12",
-        "Total files  12",
+        "Total files  13",
     ]));
     expect($code)->toBe(1);
 });

--- a/tests/misc/words-with-numbers.php
+++ b/tests/misc/words-with-numbers.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+function abort404(): void
+{
+    http_response_code(404);
+
+    echo "404 - not found";
+}


### PR DESCRIPTION
## Added

- Numbers are ignored and will not produce typo errors

## Fixed

N/A

## Breaking

N/A